### PR TITLE
Add organization info on GitHub

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+Thank you for your interest in contributing to Stately repos! Contributors like you make this project possible, and we welcome any contributions to the code base and the documentation.
+
+There are several ways you can contribute:
+
+- 📥 [Submit an issue](#submit-an-issue)
+- ✨ [Solve an issue or make a change](#making-changes)
+- 🖊️ [Write documentation](https://github.com/statelyai/docs)
+- 💬 [Respond to support questions in the XState GitHub discussions](https://github.com/statelyai/xstate/discussions)
+- 🛟 [Respond to questions in the Help channel on Discord](https://discord.gg/xstate)
+
+Please read [our code of conduct](https://github.com/statelyai/xstate/blob/main/CODE_OF_CONDUCT.md).
+
+## Making changes
+
+Pull requests are encouraged. If you want to add a feature or fix a bug:
+
+1. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) and [clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) the [repository](https://github.com/statelyai/xstate).
+2. [Create a separate branch](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-branches) for your changes.
+3. Make your changes, and ensure that it is formatted by [Prettier](https://prettier.io) and type-checks without errors in [TypeScript](https://www.typescriptlang.org/).
+4. Write tests that validate your change and/or fix.
+5. Run `yarn build` and then run tests with `yarn test` (for all packages) or `yarn test:core` (for only changes to core XState).
+6. For package changes, add docs inside the `/packages/*/README.md`. These docs will be copied on build to the corresponding `/docs/packages/*/index.md` file.
+7. Create a changeset by running `yarn changeset`. [More about changesets](https://github.com/atlassian/changesets).
+8. Push your branch and open a PR 🚀
+
+PRs are reviewed promptly and merged in within a day or two (or even within an hour) if everything looks good.
+
+## Submit an issue
+
+Issues and bug reports are also encouraged. If you want to submit an issue:
+
+1. Search existing issues to check if your issue already exists or has been solved.
+2. Create a new issue if your issue has not yet been submitted.
+3. Ensure you fill out all the details in the issue template to help us understand the issue.
+
+We’ll try to respond promptly and address your issue as soon as possible.
+
+## Contributing to our docs
+
+Our [new docs](https://stately.ai/docs) are now in their own [docs repo](https://github.com/statelyai/docs). [Read the contribution guide for our Stately Studio and XState docs](https://github.com/statelyai/docs/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Hi! We’re Stately.
+
+![The Stately team including Gavin, Farzad, David, Mateusz, Jenny, Laura, Anders, Nick, and Kevin, all standing in front of garage doors, laughing and smiling at each other.](https://ascelcgzufjyvdzuplwo.supabase.co/storage/v1/object/public/stately-brand/stately.png)
+
+We’re [Stately](https://stately.ai), a small team founded by [David Khourshid](https://twitter.com/davidkpiano), the creator of XState. We’re building Stately, where you can visualize your application logic and collaborate with your whole team.
+
+## Contribute
+
+We appreciate your contributions! There are several ways you can contribute:
+
+- 📥 [Submit an issue](#submit-an-issue)
+- ✨ [Solve an issue or make a change](#making-changes)
+- 🖊️ [Write documentation](https://github.com/statelyai/docs)
+- 💬 [Respond to support questions in the XState GitHub discussions](https://github.com/statelyai/xstate/discussions)
+- 🛟 [Respond to questions in the Help channel on Discord](https://discord.gg/xstate)
+
+Please read [our code of conduct](https://github.com/statelyai/xstate/blob/main/CODE_OF_CONDUCT.md).
+
+### Making changes
+
+Pull requests are encouraged. If you want to add a feature or fix a bug:
+
+1. Check out the `contributing.md` in the relevant repository for more detailed guidelines.
+1. [Fork](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo) and [clone](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository) the [repository](https://github.com/statelyai/xstate).
+2. [Create a separate branch](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-branches) for your changes.
+3. Make your changes.
+4. Push your branch and open a PR 🚀
+
+If everything looks good, PRs are reviewed promptly and merged within a day or two (or even within an hour.)
+
+### Submit an issue
+
+Issues and bug reports are also encouraged. If you want to submit an issue:
+
+1. Search existing issues to check if your issue already exists or has been solved.
+2. Create a new issue if your issue has not yet been submitted.
+3. Ensure you fill out all the details in the issue template to help us understand the issue.
+
+We’ll try to respond promptly and address your issue as soon as possible.
+
+### Contributing to our docs
+
+Our [new docs](https://stately.ai/docs) are now in their own [docs repo](https://github.com/statelyai/docs). [Read the contribution guide for our Stately Studio and XState docs](https://github.com/statelyai/docs/blob/main/CONTRIBUTING.md).
+
+## Give feedback
+
+We’d love your feedback! Please [post and upvote specific feature requests on our roadmap](https://feedback.stately.ai), and share your more general thoughts and feedback on [our Discord](https://discord.gg/xstate).
+
+## Keep up with the latest from Stately
+
+You’ll find us @statelyai on most social media platforms:
+
+- [Discord](https://discord.gg/xstate)
+- [LinkedIn](https://www.linkedin.com/company/statelyai/)
+- [Mastodon](https://social.stately.ai/@stately)
+- [Twitter](https://twitter.com/statelyai)
+- [Instagram](https://instagram.com/statelyai)


### PR DESCRIPTION
This PR adds default contribution guidelines (these will be added by default to all new repos) and a nice new readme which will [be used as an organization page](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile).